### PR TITLE
Closes issue #2 (deprecation warnings)

### DIFF
--- a/example.domain.tsp
+++ b/example.domain.tsp
@@ -1,6 +1,7 @@
 // example-domain.tsp
 // Example domain model for testing etc.
 
+// example-domain.tsp
 import "@typespec/http";
 import "@typespec/rest";
 import "@typespec/openapi";
@@ -9,16 +10,13 @@ using TypeSpec.Http;
 using TypeSpec.Rest;
 using TypeSpec.OpenAPI;
 
-@service({
-  title: "User Management Service",
-  version: "1.0.0"
-})
+// Define service with just a title, removing deprecated version
+@service(#{title: "User Management Service"})
 @route("/api")
 namespace Example;
 
 @doc("Represents a user in the system")
 model User {
-
   @key
   @visibility
   id: string;
@@ -45,10 +43,8 @@ model User {
   updatedAt: utcDateTime;
 }
 
-// Resource interface for User operations
 @route("/users")
 interface Users {
-  // Create a new user (POST)
   @post
   @doc("Creates a new user")
   create(@body user: User): {
@@ -59,7 +55,6 @@ interface Users {
     @body error: ErrorResponse;
   };
 
-  // Read a user by ID (GET)
   @get
   @route("/{id}")
   @doc("Gets a user by ID")
@@ -68,7 +63,6 @@ interface Users {
     @body error: ErrorResponse;
   };
 
-  // Update a user (PUT)
   @put
   @route("/{id}")
   @doc("Updates an existing user")
@@ -80,7 +74,6 @@ interface Users {
     @body error: ErrorResponse;
   };
 
-  // Delete a user (DELETE)
   @delete
   @route("/{id}")
   @doc("Deletes a user")
@@ -91,13 +84,11 @@ interface Users {
     @body error: ErrorResponse;
   };
 
-  // List all users (GET)
   @get
   @doc("Lists all users")
   list(): User[];
 }
 
-// Basic error response model
 model ErrorResponse {
   @doc("Error message")
   message: string;


### PR DESCRIPTION
# Fix for deprecation warnings 

## Description
- use object struct not model
- remove deprecated version property

## Related Issues
Closes #2 

## Changes Made
Changed @service({title: "User Management Service", version: "1.0.0"}) to @service(#{title: "User Management Service"})
Uses the new object value syntax with #{} as recommended

Removed the deprecated version property

## Additional Notes
File is not currently version tracked. (See #4) 
